### PR TITLE
Add finance contracts: adapter and goals engine

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,22 +1,28 @@
 [project]
-name = "Personal-Finance-Coach"
-description = ""
+name = 'Personal-Finance-Coach'
+description = ''
 authors = []
 telemetry = true
-cache_dir = "./.cache"
+cache_dir = '.\.cache'
+requirements = []
+[contracts.advice-engine]
+path = 'contracts/advice-engine.clar'
+clarity_version = 3
+epoch = 'latest'
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
-# epoch = "latest"
-
+[contracts.aggregation-adapter]
+path = 'contracts/aggregation-adapter.clar'
+clarity_version = 3
+epoch = '3.2'
 [repl.analysis]
-passes = ["check_checker"]
-check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
+passes = ['check_checker']
 
-# Check-checker settings:
-# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
-# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
-# callee_filter: if true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false
+
+[repl.remote_data]
+enabled = false
+api_url = 'https://api.hiro.so'

--- a/contracts/advice-engine.clar
+++ b/contracts/advice-engine.clar
@@ -1,29 +1,164 @@
-;; title: advice-engine
-;; version:
-;; summary:
-;; description:
+;; advice-engine
+;; Goals, alerts, and simple recommendations
+;; No cross-contract calls or trait usage
 
-;; traits
-;;
+(define-constant ERR-NOT-FOUND u200)
+(define-constant ERR-NOT-AUTHORIZED u201)
+(define-constant ERR-INVALID u202)
+(define-constant ERR-INACTIVE u203)
 
-;; token definitions
-;;
+(define-data-var next-goal-id uint u1)
+(define-data-var next-alert-id uint u1)
 
-;; constants
-;;
+;; goal-id => { owner, label, target, current, deadline, created, active }
+(define-map goals
+  (tuple (goal-id uint))
+  (tuple (owner principal)
+         (label (string-ascii 64))
+         (target uint)
+         (current uint)
+         (deadline uint)
+         (created uint)
+         (active bool)))
 
-;; data vars
-;;
+;; alert-id => { owner, goal-id, kind, message, created }
+(define-map alerts
+  (tuple (alert-id uint))
+  (tuple (owner principal)
+         (goal-id uint)
+         (kind (string-ascii 32))
+         (message (string-ascii 128))
+         (created uint)))
 
-;; data maps
-;;
+;; ======== helpers ========
 
-;; public functions
-;;
+(define-read-only (now) u0)
 
-;; read only functions
-;;
+(define-read-only (str-non-empty (s (string-ascii 128)))
+  (ok (> (len s) u0)))
 
-;; private functions
-;;
+(define-private (mk-alert (owner principal) (goal-id uint) (kind (string-ascii 32)) (message (string-ascii 128)))
+  (let ((id (var-get next-alert-id)))
+    (var-set next-alert-id (+ id u1))
+    (map-insert alerts { alert-id: id }
+      { owner: owner,
+        goal-id: goal-id,
+        kind: kind,
+        message: message,
+        created: (now) })
+    (ok id)))
+;; ======== public interface ========
 
+(define-public (create-goal (label (string-ascii 64)) (target uint) (deadline uint))
+  (begin
+    (if (not (unwrap! (str-non-empty label) (err ERR-INVALID)))
+        (err ERR-INVALID)
+        (if (is-eq target u0)
+            (err ERR-INVALID)
+            (let ((id (var-get next-goal-id))
+                  (created (now)))
+              (var-set next-goal-id (+ id u1))
+              (map-insert goals { goal-id: id }
+                { owner: tx-sender,
+                  label: label,
+                  target: target,
+                  current: u0,
+                  deadline: deadline,
+                  created: created,
+                  active: true })
+              (ok id))))))
+
+(define-public (contribute (goal-id uint) (amount uint))
+  (match (map-get? goals { goal-id: goal-id }) g
+    (let ((owner (get owner g))
+          (active (get active g))
+          (cur (get current g)))
+      (if (not (is-eq owner tx-sender))
+          (err ERR-NOT-AUTHORIZED)
+          (if (or (is-eq amount u0) (not active))
+              (err (if (is-eq amount u0) ERR-INVALID ERR-INACTIVE))
+              (begin
+                (map-set goals { goal-id: goal-id }
+                  { owner: owner,
+                    label: (get label g),
+                    target: (get target g),
+                    current: (+ cur amount),
+                    deadline: (get deadline g),
+                    created: (get created g),
+                    active: active })
+                (ok true)))))
+    (err ERR-NOT-FOUND)))
+
+(define-public (deactivate-goal (goal-id uint))
+  (match (map-get? goals { goal-id: goal-id }) g
+    (let ((owner (get owner g)))
+      (if (is-eq owner tx-sender)
+          (begin
+            (map-set goals { goal-id: goal-id }
+              { owner: owner,
+                label: (get label g),
+                target: (get target g),
+                current: (get current g),
+                deadline: (get deadline g),
+                created: (get created g),
+                active: false })
+            (ok true))
+          (err ERR-NOT-AUTHORIZED)))
+    (err ERR-NOT-FOUND)))
+
+;; Advice categories
+;; - "reached"      : current >= target
+;; - "behind"       : progress < 50% and time passed >= 50%
+;; - "on-track"     : otherwise
+
+(define-public (generate-advice (goal-id uint))
+  (match (map-get? goals { goal-id: goal-id }) g
+    (let ((target (get target g))
+          (current (get current g))
+          (deadline (get deadline g))
+          (created (get created g)))
+      (let ((percent (if (is-eq target u0) u0 (/ (* current u100) target)))
+            (now-ts (now))
+            (window (if (> deadline created) (- deadline created) u0))
+            (elapsed (if (> (now) created) (- now-ts created) u0)))
+        (let ((elapsed-pct (if (is-eq window u0) u0 (/ (* elapsed u100) window))))
+          (if (>= current target)
+              (begin
+                (unwrap! (mk-alert (get owner g) goal-id "status" "Goal reached") (err ERR-INVALID))
+                (ok "reached"))
+              (if (and (< percent u50) (>= elapsed-pct u50))
+                  (begin
+                    (unwrap! (mk-alert (get owner g) goal-id "advice" "You are behind schedule") (err ERR-INVALID))
+                    (ok "behind"))
+                  (begin
+                    (unwrap! (mk-alert (get owner g) goal-id "advice" "You are on track") (err ERR-INVALID))
+                    (ok "on-track")))))))
+    (err ERR-NOT-FOUND)))
+
+;; ======== read-only ========
+
+(define-read-only (get-goal (goal-id uint))
+  (match (map-get? goals { goal-id: goal-id }) g
+    (ok g)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (progress-percent (goal-id uint))
+  (match (map-get? goals { goal-id: goal-id }) g
+    (let ((target (get target g))
+          (current (get current g)))
+      (ok (if (is-eq target u0) u0 (/ (* current u100) target))))
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (is-on-track (goal-id uint))
+  (match (map-get? goals { goal-id: goal-id }) g
+    (let ((target (get target g))
+          (current (get current g))
+          (deadline (get deadline g))
+          (created (get created g)))
+      (let ((p (if (is-eq target u0) u0 (/ (* current u100) target)))
+            (now-ts (now))
+            (window (if (> deadline created) (- deadline created) u0))
+            (elapsed (if (> (now) created) (- now-ts created) u0)))
+        (let ((elapsed-pct (if (is-eq window u0) u0 (/ (* elapsed u100) window))))
+          (ok (or (>= p u50) (< elapsed-pct u50))))))
+    (err ERR-NOT-FOUND)))

--- a/contracts/advice-engine.clar
+++ b/contracts/advice-engine.clar
@@ -1,0 +1,29 @@
+;; title: advice-engine
+;; version:
+;; summary:
+;; description:
+
+;; traits
+;;
+
+;; token definitions
+;;
+
+;; constants
+;;
+
+;; data vars
+;;
+
+;; data maps
+;;
+
+;; public functions
+;;
+
+;; read only functions
+;;
+
+;; private functions
+;;
+

--- a/contracts/aggregation-adapter.clar
+++ b/contracts/aggregation-adapter.clar
@@ -1,29 +1,157 @@
-;; title: aggregation-adapter
-;; version:
-;; summary:
-;; description:
+;; aggregation-adapter
+;; Bank connection and transaction normalization
+;; No cross-contract calls or trait usage
 
-;; traits
-;;
+(define-constant ERR-NOT-FOUND u100)
+(define-constant ERR-NOT-AUTHORIZED u101)
+(define-constant ERR-INVALID u102)
+(define-constant ERR-ALREADY-NORMALIZED u103)
 
-;; token definitions
-;;
+;; Sequential identifiers
+(define-data-var next-bank-id uint u1)
+(define-data-var next-account-id uint u1)
+(define-data-var next-tx-id uint u1)
 
-;; constants
-;;
+;; bank-id => { name, owner }
+(define-map bank-registry (tuple (bank-id uint)) (tuple (name (string-ascii 64)) (owner principal)))
 
-;; data vars
-;;
+;; account-id => { bank-id, owner, label, currency }
+(define-map accounts (tuple (account-id uint)) (tuple (bank-id uint) (owner principal) (label (string-ascii 64)) (currency (string-ascii 8))))
 
-;; data maps
-;;
+;; tx-id => { account-id, amount, timestamp, merchant, category, normalized }
+(define-map transactions (tuple (tx-id uint)) (tuple (account-id uint) (amount int) (timestamp uint) (merchant (string-ascii 64)) (category (string-ascii 32)) (normalized bool)))
 
-;; public functions
-;;
+;; =============
+;; helpers
+;; =============
 
-;; read only functions
-;;
+(define-read-only (is-owner (who principal) (principal-owner principal))
+  (ok (is-eq who principal-owner)))
 
-;; private functions
-;;
+(define-read-only (str-non-empty (s (string-ascii 128)))
+  (ok (> (len s) u0)))
 
+(define-read-only (bank-exists (bank-id uint))
+  (ok (is-some (map-get? bank-registry { bank-id: bank-id }))))
+
+(define-read-only (account-exists (account-id uint))
+  (ok (is-some (map-get? accounts { account-id: account-id }))))
+
+(define-read-only (tx-exists (tx-id uint))
+  (ok (is-some (map-get? transactions { tx-id: tx-id }))))
+
+;; =============
+;; public interface
+;; =============
+
+(define-public (register-bank (name (string-ascii 64)))
+  (begin
+    (if (not (unwrap! (str-non-empty name) (err ERR-INVALID)))
+        (err ERR-INVALID)
+        (let ((id (var-get next-bank-id)))
+          (var-set next-bank-id (+ id u1))
+          (map-insert bank-registry { bank-id: id }
+            { name: name, owner: tx-sender })
+          (ok id)))))
+
+(define-public (open-account (bank-id uint) (label (string-ascii 64)) (currency (string-ascii 8)))
+  (begin
+    (if (not (unwrap! (bank-exists bank-id) (err ERR-NOT-FOUND)))
+        (err ERR-NOT-FOUND)
+        (if (and (> (len label) u0) (> (len currency) u0))
+            (let ((id (var-get next-account-id)))
+              (var-set next-account-id (+ id u1))
+              (map-insert accounts { account-id: id }
+                { bank-id: bank-id,
+                  owner: tx-sender,
+                  label: label,
+                  currency: currency })
+              (ok id))
+            (err ERR-INVALID)))))
+
+(define-public (record-transaction
+    (account-id uint)
+    (amount int)
+    (timestamp uint)
+    (merchant (string-ascii 64))
+    (category (string-ascii 32)))
+  (begin
+    (match (map-get? accounts { account-id: account-id }) account
+      (let ((owner (get owner account)))
+        (if (not (unwrap! (is-owner tx-sender owner) (err ERR-NOT-AUTHORIZED)))
+            (err ERR-NOT-AUTHORIZED)
+            (if (and (not (is-eq amount 0)) (> (len merchant) u0))
+                (let ((id (var-get next-tx-id)))
+                  (var-set next-tx-id (+ id u1))
+                  (map-insert transactions { tx-id: id }
+                    { account-id: account-id,
+                      amount: amount,
+                      timestamp: timestamp,
+                      merchant: merchant,
+                      category: category,
+                      normalized: false })
+                  (ok id))
+                (err ERR-INVALID))))
+      (err ERR-NOT-FOUND))))
+
+(define-public (set-category (tx-id uint) (category (string-ascii 32)))
+  (begin
+    (match (map-get? transactions { tx-id: tx-id }) tx
+      (let ((acct-id (get account-id tx)))
+        (match (map-get? accounts { account-id: acct-id }) acct
+          (let ((owner (get owner acct)))
+            (if (not (unwrap! (is-owner tx-sender owner) (err ERR-NOT-AUTHORIZED)))
+                (err ERR-NOT-AUTHORIZED)
+                (if (> (len category) u0)
+                    (begin
+                      (map-set transactions { tx-id: tx-id }
+                        { account-id: (get account-id tx),
+                          amount: (get amount tx),
+                          timestamp: (get timestamp tx),
+                          merchant: (get merchant tx),
+                          category: category,
+                          normalized: (get normalized tx) })
+                      (ok true))
+                    (err ERR-INVALID))))
+          (err ERR-NOT-FOUND)))
+      (err ERR-NOT-FOUND))))
+
+(define-public (normalize-transaction (tx-id uint))
+  (begin
+    (match (map-get? transactions { tx-id: tx-id }) tx
+      (let ((already (get normalized tx))
+            (cat (get category tx))
+            (amt (get amount tx)))
+        (if already
+            (err ERR-ALREADY-NORMALIZED)
+            (if (and (> (len cat) u0) (not (is-eq amt 0)))
+                (begin
+                  (map-set transactions { tx-id: tx-id }
+                    { account-id: (get account-id tx),
+                      amount: amt,
+                      timestamp: (get timestamp tx),
+                      merchant: (get merchant tx),
+                      category: cat,
+                      normalized: true })
+                  (ok true))
+                (err ERR-INVALID))))
+      (err ERR-NOT-FOUND))))
+
+;; =============
+;; read-only getters
+;; =============
+
+(define-read-only (get-bank (bank-id uint))
+  (match (map-get? bank-registry { bank-id: bank-id }) bank
+    (ok bank)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (get-account (account-id uint))
+  (match (map-get? accounts { account-id: account-id }) acct
+    (ok acct)
+    (err ERR-NOT-FOUND)))
+
+(define-read-only (get-transaction (tx-id uint))
+  (match (map-get? transactions { tx-id: tx-id }) tx
+    (ok tx)
+    (err ERR-NOT-FOUND)))

--- a/contracts/aggregation-adapter.clar
+++ b/contracts/aggregation-adapter.clar
@@ -1,0 +1,29 @@
+;; title: aggregation-adapter
+;; version:
+;; summary:
+;; description:
+
+;; traits
+;;
+
+;; token definitions
+;;
+
+;; constants
+;;
+
+;; data vars
+;;
+
+;; data maps
+;;
+
+;; public functions
+;;
+
+;; read only functions
+;;
+
+;; private functions
+;;
+

--- a/tests/advice-engine.test.ts
+++ b/tests/advice-engine.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initialised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});

--- a/tests/aggregation-adapter.test.ts
+++ b/tests/aggregation-adapter.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initialised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# PR: Personal-Finance-Coach contracts

Summary

This PR introduces two Clarity contracts for a simple personal finance system:
- aggregation-adapter: bank and account management with transaction recording and normalization
- advice-engine: goal tracking with basic progress-based advice and alert logging

Changes

- New: contracts/aggregation-adapter.clar
  - Bank registry with sequential IDs
  - Accounts per principal with currency/label
  - Transactions with amount, timestamp, merchant, category, normalized flag
  - Public actions: register-bank, open-account, record-transaction, set-category, normalize-transaction
  - Read-only: get-bank, get-account, get-transaction

- New: contracts/advice-engine.clar
  - Goals per principal (label, target, current, deadline, created, active)
  - Alerts storage for status/advice logs
  - Public actions: create-goal, contribute, deactivate-goal, generate-advice
  - Read-only: get-goal, progress-percent, is-on-track

How to validate

- clarinet check
  Compiles and type-checks both contracts.

Notes

- No cross-contract calls or trait usage (as required).
- Advice uses coarse thresholds: "reached", "behind", "on-track".
- Time-dependent logic uses a constant placeholder for now() to keep the demo deterministic.
